### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -66,7 +66,7 @@ Resources:
     Properties:
       CodeUri: s3://severless-ticket-sentiment-analysis-and-automated-escalation/29a5110383ba75c318738b375cdae561
       Handler: getFullTicket.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Role:
         Fn::GetAtt:
         - DemoLambdaExecutionRole
@@ -84,7 +84,7 @@ Resources:
     Properties:
       CodeUri: s3://severless-ticket-sentiment-analysis-and-automated-escalation/6031eaec5573fb2adaa96645627435c9
       Handler: getSentiment.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Role:
         Fn::GetAtt:
         - DemoLambdaExecutionRole
@@ -95,7 +95,7 @@ Resources:
     Properties:
       CodeUri: s3://severless-ticket-sentiment-analysis-and-automated-escalation/1989be8a590b85764342e96fae93d49a
       Handler: setTags.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Role:
         Fn::GetAtt:
         - DemoLambdaExecutionRole
@@ -113,7 +113,7 @@ Resources:
     Properties:
       CodeUri: s3://severless-ticket-sentiment-analysis-and-automated-escalation/bbfa7302ac7ad61b71d97afb8adc867e
       Handler: setPriority.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Role:
         Fn::GetAtt:
         - DemoLambdaExecutionRole

--- a/template.yml
+++ b/template.yml
@@ -85,7 +85,7 @@ Resources:
         Properties:
             CodeUri: lambdas/getFullTicket
             Handler: getFullTicket.handler
-            Runtime: nodejs10.x
+            Runtime: nodejs14.x
             Role:
                 Fn::GetAtt:
                 - DemoLambdaExecutionRole
@@ -100,7 +100,7 @@ Resources:
         Properties:
             CodeUri: lambdas/getSentiment
             Handler: getSentiment.handler
-            Runtime: nodejs10.x
+            Runtime: nodejs14.x
             Role:
                 Fn::GetAtt:
                 - DemoLambdaExecutionRole
@@ -111,7 +111,7 @@ Resources:
         Properties:
             CodeUri: lambdas/setTags
             Handler: setTags.handler
-            Runtime: nodejs10.x
+            Runtime: nodejs14.x
             Role:
                 Fn::GetAtt:
                 - DemoLambdaExecutionRole
@@ -126,7 +126,7 @@ Resources:
         Properties:
             CodeUri: lambdas/setPriority
             Handler: setPriority.handler
-            Runtime: nodejs10.x
+            Runtime: nodejs14.x
             Role:
                 Fn::GetAtt:
                 - DemoLambdaExecutionRole


### PR DESCRIPTION
CloudFormation templates in severless-ticket-sentiment-analysis-and-automated-escalation have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.